### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,6 +8,11 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  packages: write
+  actions: write
+
 jobs:
   build:
     name: Build Kenku FM


### PR DESCRIPTION
Potential fix for [https://github.com/Fronix/kenku-fm/security/code-scanning/1](https://github.com/Fronix/kenku-fm/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, the following permissions are needed:
- `contents: read` for accessing repository contents.
- `packages: write` for signing and uploading packages.
- `actions: write` for interacting with GitHub Actions.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`build`) to limit permissions to that job only. In this case, adding it at the root level is more concise and ensures all jobs adhere to the same permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
